### PR TITLE
Docs decoration rules UPD

### DIFF
--- a/delivery/project-management.md
+++ b/delivery/project-management.md
@@ -1,7 +1,7 @@
 # GitHub Project Management
 
 Here is stack of rules what recommended to use for making cyber•Congress great again.
-As a public open source organization with high-level goals and values we need to delivering transparent information for community.
+As a public open source organization with high-level goals and values we need to deliverашч  transparent information for community.
 
 
 ## Pull request and issue formalization

--- a/delivery/project-management.md
+++ b/delivery/project-management.md
@@ -1,7 +1,7 @@
 # GitHub Project Management
 
 Here is stack of rules what recommended to use for making cyber•Congress great again.
-As a public open source organization with high-level goals and values we need to deliverашч  transparent information for community.
+As a public open source organization with high-level goals and values we need to deliver transparent information for community.
 
 
 ## Pull request and issue formalization

--- a/delivery/project-management.md
+++ b/delivery/project-management.md
@@ -43,15 +43,14 @@ Automatic changelog generator is in process of attaching to each repo. This scri
 
 ## Docs decorating
 
-All documentation about repo you should keep at `/docs` folder. Automatic script will collect all docs in knowledge and deploy them to https://cybersearch.io/ .
+All documentation about repo you should keep at `/docs` folder. Automatic script will collect all docs in knowledge and deploy them to https://wiki.cybercongress.ai/ .
 For now there are few requirements to keep docs:
 
 - store you docs in `/docs` folder in your repo;
 - if you want to publish them at knowledge commit all docs changes in `master`;
-- add `about $repo_name$.md` to your docs;
-- keep doc naming same with `h1` of document;
->f.e. `bitcoin-pump-development.md` this doc should starts with `# Bitcoin Pump Development`. No more no less.
-- keep your documentation in actual state.
+- add overview `$repo_name$.md` to your docs;
+- edit table of content at your `$repo_name$.yml` file at the root of yout repo.
+
 
 ## Templates
 

--- a/delivery/project-management.md
+++ b/delivery/project-management.md
@@ -49,7 +49,8 @@ For now there are few requirements to keep docs:
 - store you docs in `/docs` folder in your repo;
 - if you want to publish them at knowledge commit all docs changes in `master`;
 - add overview `$repo_name$.md` to your docs;
-- edit table of content at your `$repo_name$.yml` file at the root of yout repo.
+- edit table of content at your `$repo_name$.yml` file at the root of yout repo;
+- keep your docs in actual state.
 
 
 ## Templates

--- a/wiki/toc_collector.sh
+++ b/wiki/toc_collector.sh
@@ -1,0 +1,10 @@
+rm -rf ./mkdocs.yml
+touch mkdocs.yml
+cat config.yml >> mkdocs.yml
+cat docs/cyb/cyb.yml >> mkdocs.yml
+cat docs/cyberd/cyberd.yml >> mkdocs.yml
+cat docs/сhaingear/chaingear.yml >> mkdocs.yml
+cat docs/cybernode/cybernode.yml >> mkdocs.yml
+cat docs/cyber-markets/cyber-markets.yml >> mkdocs.yml
+cat docs/cyber-search/cyber-search.yml >> mkdocs.yml
+cat docs/cyb-js/cyb-js.yml >> mkdocs.yml


### PR DESCRIPTION
Now all docs collect from project repos to Congress repo and deploy to https://wiki.cybercongress.ai/ 
I would love to add `$repo_name$.yml` file to each repo where you can create table of content as you wish. How to do this explained [here](https://github.com/cybercongress/congress/blob/GitHub_PM_UPD/delivery/project-management.md#docs-decorating).